### PR TITLE
hide Data.List.sortOn

### DIFF
--- a/diff-du.hs
+++ b/diff-du.hs
@@ -1,6 +1,6 @@
 import Data.Char (isDigit)
 import Data.Either
-import Data.List
+import Data.List hiding (sortOn)
 import System.Console.GetOpt
 import System.Directory
 import System.Environment


### PR DESCRIPTION
because [Data.List](https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-List.html#v:sortOn) provides `sortOn` meanwhile.

```
$ ghc diff-du.hs 
[1 of 1] Compiling Main             ( diff-du.hs, diff-du.o )

diff-du.hs:100:14: error:
    Ambiguous occurrence ‘sortOn’
    It could refer to either ‘Data.List.sortOn’,
                             imported from ‘Data.List’ at diff-du.hs:3:1-16
                             (and originally defined in ‘base-4.10.1.0:Data.OldList’)
                          or ‘Main.sortOn’, defined at diff-du.hs:96:1
    |
100 | sortDuOn f = sortOn f . map (\(Du p s cs) -> Du p s (sortDuOn f cs))
```